### PR TITLE
Сore field updates for Personal Page

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   ui-tests:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This project is for writing and running automated tests using **Pytest** & **Playwright** (TBD)
 
 ### Initial Setup
-- [ ] Install [Python](https://www.python.org/downloads/) (version 3.12 or later)
+- [ ] Install [Python](https://www.python.org/downloads/) (version 3.13+)
 - [ ] Install [PDM](https://pdm-project.org/latest/#recommended-installation-method) for dependency management
 - [ ] Create and activate a virtual environment: `python3 -m venv .venv && source .venv/bin/activate`
 - [ ] Install project dependencies: `pdm lock && pdm sync`
@@ -17,27 +17,31 @@ This project is for writing and running automated tests using **Pytest** & **Pla
 
 ### Running Tests Locally
 #### Through Terminal:
-- Run the test: `pytest -s -v tests/path_to_file_or_directory`
-- Add the following to the command to generate a report (json files): `--alluredir=allure-results`
-
-#### Through IDE:
-- Check in the interpreter settings that the `.venv` virtual environment of the project is selected
-- Run tests using the "**run**" button or play icon, depending on your IDE
+- Basic Run: `pytest -sv tests/path_to_file_or_directory`
+- Run with Browser UI / Headed: `pytest -sv --headed tests/path_to_file_or_directory`
+- Run with Slow Interactions / Debug:`pytest -sv --headed --slowmo 500 tests/path_to_file_or_directory`
+- Generate Allure Reports: `pytest -sv --alluredir=allure-results tests/path_to_file_or_directory`
 
 ### Running Tests in GitHub Actions
 #### Manual Run:
-- Access the [GitHub Actions page](https://github.com/darliro/QAAPractice/actions)
-- Click the **Run workflow** button on the relevant workflow
-- Click **Run workflow** again
+- Go to [GitHub Actions page](https://github.com/darliro/QAAPractice/actions)
+- Find the desired workflow (e.g., UI Tests)
+- Click the **Run workflow** button
+- Select the branch you want to run
+- Click **Run workflow** again to trigger the execution
 
 ### Allure Report Setup
 - Install [Allure Report](https://docs.qameta.io/allure/#_installing_a_commandline)
 - Generate a report based on the latest test run: `allure generate allure-results --clean -o allure-report`
-- Open the report in a browser: `allure open allure-report`
+- Open the report locally: `allure open allure-report`
 
 ### Code Linting and Formatting with [ruff](https://github.com/astral-sh/ruff)
-- Run the linter to check code for errors: `ruff check path_to_file_or_folder` (with autofix: add `--fix`, for the entire project: add `.` at the end)
-- Run the formatter to standardize code style: `ruff format path_to_file_or_folder` (with autofix: add `--fix`, for the entire project: add `.`)
+- Check Code Quality: `ruff check path_to_file_or_folder`
+- Autofix Errors: `ruff check path_to_file_or_folder --fix`
+- Format Code: `ruff format path_to_file_or_folder --fix`
 
-`Tip:`
-At each level of the `tests` folder, you can have a `conftest.py` with fixtures or hooks specific to that level of tests.
+`Tips:`
+- Usage of `conftest.py`:
+At each level of the tests folder, you can place a `conftest.py` with fixtures or hooks specific to that level of testing
+- Simulating **Debug Runs**:
+Use `--headed` and `--slowmo` options to visually debug tests with browser UI and control interaction speeds

--- a/base/base_page.py
+++ b/base/base_page.py
@@ -55,3 +55,12 @@ class BasePage:
     def verify_dropdown_value(self, locator: str, expected_value: str) -> None:
         self.wait_for_element(locator)
         expect(self.page.locator(locator)).to_have_text(expected_value.strip())
+
+    @allure.step("Verify selected value in radio: {locator}")
+    def verify_radio_selected(self, locator: str) -> None:
+        self.wait_for_element(locator)
+        class_value = self.page.locator(locator).get_attribute("class")
+        assert (
+            "oxd-radio-input--active"
+            in self.page.locator(locator).get_attribute("class")
+        ), f"Expected 'oxd-radio-input--active' in class attribute, but got: {class_value}"

--- a/base/base_page.py
+++ b/base/base_page.py
@@ -50,3 +50,8 @@ class BasePage:
         expect(self.page.locator(locator)).to_have_value(
             expected_value, timeout=timeout
         )
+
+    @allure.step("Verify selected value in dropdown: {locator}")
+    def verify_dropdown_value(self, locator: str, expected_value: str) -> None:
+        self.wait_for_element(locator)
+        expect(self.page.locator(locator)).to_have_text(expected_value.strip())

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ DATA_GENERATORS = {
     "date": lambda: datetime.now().strftime("%Y-%d-%m"),
     "nationality": lambda: "Afghan",
     "marital_status": lambda: "Single",
+    "gender": lambda: "Female",
 }
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,7 @@ DATA_GENERATORS = {
     "id": lambda: faker.unique.bothify(text="??????????"),
     "date": lambda: datetime.now().strftime("%Y-%d-%m"),
     "nationality": lambda: "Afghan",
+    "marital_status": lambda: "Single",
 }
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ DATA_GENERATORS = {
     "middle_name": lambda: faker.name_nonbinary(),
     "id": lambda: faker.unique.bothify(text="??????????"),
     "date": lambda: datetime.now().strftime("%Y-%d-%m"),
+    "nationality": lambda: "Afghan",
 }
 
 

--- a/pages/personal_page.py
+++ b/pages/personal_page.py
@@ -11,6 +11,7 @@ class PersonalPage(BasePage):
     MIDDLE_NAME_INPUT = "input[name='middleName']"
     EMPLOYEE_ID_INPUT = "//label[text()='Employee Id']/following::input[1]"
     OTHER_ID_INPUT = "//label[text()='Other Id']/following::input[1]"
+
     DRIVERS_LICENSE_NUMBER_INPUT = (
         '//label[text()="Driver\'s License Number"]/following::input[1]'
     )
@@ -26,6 +27,9 @@ class PersonalPage(BasePage):
     )
     SECOND_OPTION_IN_MARITAL_STATUS_LIST = "(//div[@role='option'])[2]"
     SELECTED_MARITAL_STATUS_TEXT = "(//div[@class='oxd-select-text-input'])[2]"
+
+    DATE_OF_BIRTH_DATE_INPUT = "(//input[@placeholder='yyyy-dd-mm'])[2]"
+    GENDER_RADIOBUTTON = "(//span[contains(@class, 'oxd-radio-input')])[2]"
 
     SAVE_BUTTON = "//p[contains(@class, 'orangehrm-form-hint')]/following-sibling::button[@type='submit']"
     LOADING_SPINNER = ".oxd-loading-spinner"
@@ -73,6 +77,15 @@ class PersonalPage(BasePage):
         self.click_element(self.MARITAL_STATUS_DROPDOWN_BUTTON)
         self.click_element(self.SECOND_OPTION_IN_MARITAL_STATUS_LIST)
 
+    @allure.step("Set date of birth to today")
+    def set_date_of_birth_to_today(self) -> None:
+        self.click_element(self.DATE_OF_BIRTH_DATE_INPUT)
+        self.select_today_date()
+
+    @allure.step("Update gender to the second option in the list")
+    def update_gender_to_second_option(self) -> None:
+        self.click_element(self.GENDER_RADIOBUTTON)
+
     @allure.step("Click 'Save' button")
     def click_save_button(self) -> None:
         self.click_element(self.SAVE_BUTTON)
@@ -116,6 +129,15 @@ class PersonalPage(BasePage):
     def verify_nationality_is_updated(self, expected_value: str) -> None:
         self.verify_dropdown_value(self.SELECTED_NATIONALITY_TEXT, expected_value)
 
-    @allure.step("Verify selected nationality is '{expected_value}'")
+    @allure.step("Verify selected marital status is '{expected_value}'")
     def verify_marital_status_is_updated(self, expected_value: str) -> None:
         self.verify_dropdown_value(self.SELECTED_MARITAL_STATUS_TEXT, expected_value)
+
+    @allure.step("Verify date of birth is updated to '{expected_date_of_birth}'")
+    def verify_date_of_birth_is_updated(self, expected_date_of_birth: str) -> None:
+        self.verify_field_value(self.DATE_OF_BIRTH_DATE_INPUT, expected_date_of_birth)
+
+    @allure.step("Verify gender is updated to '{expected_gender}'")
+    def verify_gender_is_updated(self, expected_gender: str) -> None:
+        if expected_gender.lower() == "female":
+            self.verify_radio_selected(self.GENDER_RADIOBUTTON)

--- a/pages/personal_page.py
+++ b/pages/personal_page.py
@@ -16,9 +16,17 @@ class PersonalPage(BasePage):
     )
     LICENSE_EXPIRY_DATE_INPUT = "(//input[@placeholder='yyyy-dd-mm'])[1]"
     TODAY_DATEPICKER = "div.oxd-date-input-link.--today"
+
     NATIONALITY_DROPDOWN_BUTTON = "(//i[contains(@class, 'oxd-select-text--arrow')])[1]"
     SECOND_OPTION_IN_NATIONALITY_LIST = "(//div[@role='option'])[2]"
     SELECTED_NATIONALITY_TEXT = "(//div[@class='oxd-select-text-input'])[1]"
+
+    MARITAL_STATUS_DROPDOWN_BUTTON = (
+        "(//i[contains(@class, 'oxd-select-text--arrow')])[2]"
+    )
+    SECOND_OPTION_IN_MARITAL_STATUS_LIST = "(//div[@role='option'])[2]"
+    SELECTED_MARITAL_STATUS_TEXT = "(//div[@class='oxd-select-text-input'])[2]"
+
     SAVE_BUTTON = "//p[contains(@class, 'orangehrm-form-hint')]/following-sibling::button[@type='submit']"
     LOADING_SPINNER = ".oxd-loading-spinner"
 
@@ -59,6 +67,11 @@ class PersonalPage(BasePage):
     def update_nationality_to_second_option(self) -> None:
         self.click_element(self.NATIONALITY_DROPDOWN_BUTTON)
         self.click_element(self.SECOND_OPTION_IN_NATIONALITY_LIST)
+
+    @allure.step("Update marital status to the second option in the list")
+    def update_marital_status_to_second_option(self) -> None:
+        self.click_element(self.MARITAL_STATUS_DROPDOWN_BUTTON)
+        self.click_element(self.SECOND_OPTION_IN_MARITAL_STATUS_LIST)
 
     @allure.step("Click 'Save' button")
     def click_save_button(self) -> None:
@@ -102,3 +115,7 @@ class PersonalPage(BasePage):
     @allure.step("Verify selected nationality is '{expected_value}'")
     def verify_nationality_is_updated(self, expected_value: str) -> None:
         self.verify_dropdown_value(self.SELECTED_NATIONALITY_TEXT, expected_value)
+
+    @allure.step("Verify selected nationality is '{expected_value}'")
+    def verify_marital_status_is_updated(self, expected_value: str) -> None:
+        self.verify_dropdown_value(self.SELECTED_MARITAL_STATUS_TEXT, expected_value)

--- a/pages/personal_page.py
+++ b/pages/personal_page.py
@@ -16,6 +16,9 @@ class PersonalPage(BasePage):
     )
     LICENSE_EXPIRY_DATE_INPUT = "(//input[@placeholder='yyyy-dd-mm'])[1]"
     TODAY_DATEPICKER = "div.oxd-date-input-link.--today"
+    NATIONALITY_DROPDOWN_BUTTON = "(//i[contains(@class, 'oxd-select-text--arrow')])[1]"
+    SECOND_OPTION_IN_NATIONALITY_LIST = "(//div[@role='option'])[2]"
+    SELECTED_NATIONALITY_TEXT = "(//div[@class='oxd-select-text-input'])[1]"
     SAVE_BUTTON = "//p[contains(@class, 'orangehrm-form-hint')]/following-sibling::button[@type='submit']"
     LOADING_SPINNER = ".oxd-loading-spinner"
 
@@ -51,6 +54,11 @@ class PersonalPage(BasePage):
     @allure.step("Select 'Today' in date picker")
     def select_today_date(self) -> None:
         self.click_element(self.TODAY_DATEPICKER)
+
+    @allure.step("Update nationality to the second option in the list")
+    def update_nationality_to_second_option(self) -> None:
+        self.click_element(self.NATIONALITY_DROPDOWN_BUTTON)
+        self.click_element(self.SECOND_OPTION_IN_NATIONALITY_LIST)
 
     @allure.step("Click 'Save' button")
     def click_save_button(self) -> None:
@@ -90,3 +98,7 @@ class PersonalPage(BasePage):
     @allure.step("Verify license expiry date is updated to '{expected_expiry_date}'")
     def verify_license_expiry_date_is_updated(self, expected_expiry_date: str) -> None:
         self.verify_field_value(self.LICENSE_EXPIRY_DATE_INPUT, expected_expiry_date)
+
+    @allure.step("Verify selected nationality is '{expected_value}'")
+    def verify_nationality_is_updated(self, expected_value: str) -> None:
+        self.verify_dropdown_value(self.SELECTED_NATIONALITY_TEXT, expected_value)

--- a/tests/profile_change_test.py
+++ b/tests/profile_change_test.py
@@ -16,6 +16,8 @@ class TestProfileFeature(BaseTest):
         expiry_date = data_generator("date")
         nationality = data_generator("nationality")
         marital_status = data_generator("marital_status")
+        date_of_birth = data_generator("date")
+        gender = data_generator("gender")
 
         with allure.step("Login and navigate to dashboard"):
             self.login_page.open_page()
@@ -38,6 +40,8 @@ class TestProfileFeature(BaseTest):
             self.personal_page.set_expiry_date_to_today()
             self.personal_page.update_nationality_to_second_option()
             self.personal_page.update_marital_status_to_second_option()
+            self.personal_page.set_date_of_birth_to_today()
+            self.personal_page.update_gender_to_second_option()
             self.personal_page.click_save_button()
 
         with allure.step("Verify profile information update"):
@@ -52,6 +56,8 @@ class TestProfileFeature(BaseTest):
             self.personal_page.verify_license_expiry_date_is_updated(expiry_date)
             self.personal_page.verify_nationality_is_updated(nationality)
             self.personal_page.verify_marital_status_is_updated(marital_status)
+            self.personal_page.verify_date_of_birth_is_updated(date_of_birth)
+            self.personal_page.verify_gender_is_updated(gender)
 
         with allure.step("Capture screenshot after update"):
             self.personal_page.make_screenshot("Profile_info_change_success")

--- a/tests/profile_change_test.py
+++ b/tests/profile_change_test.py
@@ -15,6 +15,7 @@ class TestProfileFeature(BaseTest):
         drivers_license_number = data_generator("id")
         expiry_date = data_generator("date")
         nationality = data_generator("nationality")
+        marital_status = data_generator("marital_status")
 
         with allure.step("Login and navigate to dashboard"):
             self.login_page.open_page()
@@ -36,6 +37,7 @@ class TestProfileFeature(BaseTest):
             self.personal_page.update_drivers_license_number(drivers_license_number)
             self.personal_page.set_expiry_date_to_today()
             self.personal_page.update_nationality_to_second_option()
+            self.personal_page.update_marital_status_to_second_option()
             self.personal_page.click_save_button()
 
         with allure.step("Verify profile information update"):
@@ -49,6 +51,7 @@ class TestProfileFeature(BaseTest):
             )
             self.personal_page.verify_license_expiry_date_is_updated(expiry_date)
             self.personal_page.verify_nationality_is_updated(nationality)
+            self.personal_page.verify_marital_status_is_updated(marital_status)
 
         with allure.step("Capture screenshot after update"):
             self.personal_page.make_screenshot("Profile_info_change_success")

--- a/tests/profile_change_test.py
+++ b/tests/profile_change_test.py
@@ -14,6 +14,7 @@ class TestProfileFeature(BaseTest):
         other_id = data_generator("id")
         drivers_license_number = data_generator("id")
         expiry_date = data_generator("date")
+        nationality = data_generator("nationality")
 
         with allure.step("Login and navigate to dashboard"):
             self.login_page.open_page()
@@ -34,6 +35,7 @@ class TestProfileFeature(BaseTest):
             self.personal_page.update_other_id(other_id)
             self.personal_page.update_drivers_license_number(drivers_license_number)
             self.personal_page.set_expiry_date_to_today()
+            self.personal_page.update_nationality_to_second_option()
             self.personal_page.click_save_button()
 
         with allure.step("Verify profile information update"):
@@ -46,6 +48,7 @@ class TestProfileFeature(BaseTest):
                 drivers_license_number
             )
             self.personal_page.verify_license_expiry_date_is_updated(expiry_date)
+            self.personal_page.verify_nationality_is_updated(nationality)
 
         with allure.step("Capture screenshot after update"):
             self.personal_page.make_screenshot("Profile_info_change_success")


### PR DESCRIPTION
- Refactored base_page.py to ensure consistency across verification methods
- Added new test methods to personal_page.py for updating and verifying gender with radio buttons
- Integrated generated data values from the factory for all the core fields, ensuring maintainability and scalability
- CI configuration: Adjusted GitHub Actions workflow to enable manual test runs.
- README updated: Added improved documentation on running Playwright tests locally with detailed example commands.